### PR TITLE
fix(vite-config): Fix the base URL

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,4 +5,5 @@ import tailwindcss from "@tailwindcss/vite"
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  base: "/gsap_cocktails/",
 })


### PR DESCRIPTION
This PR sets a base URL based on the Vite docs:
https://vite.dev/guide/static-deploy.html#github-pages